### PR TITLE
fix: Correct vertex transformation calculation logic

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -978,7 +978,6 @@ def save_mesh(out_dir, params, variables, frame, res=1024, gen_texture=True):
     else:
         vertices = params["means3D"].clone().detach().cpu().numpy()
 
-    vertices = np.concatenate((vertices, np.ones((vertices.shape[0], 1))), axis=-1)  # turn to homogeneous coords
     trans_g = np.linalg.inv(variables["trans_g"])
     vertices = vertices @ trans_g[:3, :3].T
     vertices = vertices + trans_g[:3, 3]

--- a/helpers.py
+++ b/helpers.py
@@ -980,8 +980,8 @@ def save_mesh(out_dir, params, variables, frame, res=1024, gen_texture=True):
 
     vertices = np.concatenate((vertices, np.ones((vertices.shape[0], 1))), axis=-1)  # turn to homogeneous coords
     trans_g = np.linalg.inv(variables["trans_g"])
-    vertices = trans_g.dot(vertices.T).T  # 
-    vertices = vertices[:, :3] / vertices[:, 3][:, np.newaxis]  # turn to non-homogeneous coords
+    vertices = vertices @ trans_g[:3, :3].T
+    vertices = vertices + trans_g[:3, 3]
     
     write_obj_with_uv(os.path.join(out_dir, "face.obj"),
                 vertices, copy.deepcopy(variables['faces_ori']),

--- a/train.py
+++ b/train.py
@@ -123,9 +123,8 @@ def initialize_params(args, trans_g):
     uvs_texture_ori = get_vertex_uvs(scene)
 
     trans_g = np.linalg.inv(trans_g)  # global transform
-    vertices = np.concatenate((vertices, np.ones((vertices.shape[0], 1))), axis=-1)  # turn to homogeneous coords
-    vertices = trans_g.dot(vertices.T).T  # 
-    vertices = vertices[:, :3] / vertices[:, 3][:, np.newaxis]  # turn to non-homogeneous coords
+    vertices = vertices @ trans_g[:3, :3].T
+    vertices = vertices + trans_g[:3, 3]
 
     colors = compute_vertex_colors(scene)
 


### PR DESCRIPTION
- Fix incorrect vertex transformation that caused improper mesh deformation
- Replace complex homogeneous coordinate transformation with straightforward 3D transformation
- Split transformation into explicit rotation and translation steps for clarity

The previous implementation using homogeneous coordinates was causing unexpected behavior in vertex transformations. Simplified the calculation by directly applying rotation matrix and translation vector separately, which resolved the transformation issues.

Issue: #13